### PR TITLE
Implemented geolocation for desktop

### DIFF
--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -15,7 +15,7 @@ type FetchConfigWithOptions = {
 
 const BASE_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
 
-// api request config
+// Api request config
 const requestConfig: FetchConfigWithOptions = {
     method: 'POST',
 };
@@ -23,9 +23,9 @@ const requestConfig: FetchConfigWithOptions = {
 const getCurrentPosition: GetCurrentPosition = (
     success,
     error,
-    options, // we will ignore options.maximumAge and options.enableHighAccuracy since cant pass it to geolocate api directly
+    options, // We will ignore options.maximumAge and options.enableHighAccuracy since cant pass it to geolocate api directly
 ) => {
-    // emulate the timeout param with an abort signal
+    // Emulate the timeout param with an abort signal
     let timeoutID: NodeJS.Timeout;
     if (options?.timeout) {
         const abortController = new AbortController();
@@ -45,39 +45,39 @@ const getCurrentPosition: GetCurrentPosition = (
             return response.json();
         })
         .then((response: GoogleAPIsGeoLocateResponse) => {
-            // transform response to match with the window.navigator.geolocation.getCurrentPosition response
+            // Transform response to match with the window.navigator.geolocation.getCurrentPosition response
             const transformedResponse = {
                 coords: {
                     latitude: response.location.lat,
                     longitude: response.location.lng,
                     accuracy: response.accuracy,
-                    // return null for these keys as we don't get them in response when api is directly called
+                    // Return null for these keys as we don't get them in response when api is directly called
                     altitude: null,
                     altitudeAccuracy: null,
                     heading: null,
                     speed: null,
                 },
-                timestamp: Date.now(), // the api call doesn't return timestamp directly, so we emulate ourselves
+                timestamp: Date.now(), // The api call doesn't return timestamp directly, so we emulate ourselves
             };
 
             success(transformedResponse);
         })
         .catch((apiError) => {
-            // the base error object when api call fails
+            // The base error object when api call fails
             const baseErrorObject = {
-                // since we are making a direct api call, we won't get permission denied error code
+                // Since we are making a direct api call, we won't get permission denied error code
                 PERMISSION_DENIED: GeolocationErrorCode.PERMISSION_DENIED,
                 POSITION_UNAVAILABLE: GeolocationErrorCode.POSITION_UNAVAILABLE,
                 TIMEOUT: GeolocationErrorCode.TIMEOUT,
                 NOT_SUPPORTED: GeolocationErrorCode.NOT_SUPPORTED,
             };
 
-            // return timeout error on abort
+            // Return timeout error on abort
             if (apiError instanceof Error && apiError.message === 'The user aborted a request.') {
                 error({
                     ...baseErrorObject,
                     code: GeolocationErrorCode.TIMEOUT,
-                    // adds a generic message for desktop, when timeout occurs
+                    // Adds a generic message for desktop, when timeout occurs
                     message: 'timeout',
                 });
                 return;
@@ -86,13 +86,13 @@ const getCurrentPosition: GetCurrentPosition = (
             error({
                 ...baseErrorObject,
                 code: GeolocationErrorCode.POSITION_UNAVAILABLE,
-                // adding a generic message for desktop, position unavailable can mean 'no internet'
+                // Adding a generic message for desktop, position unavailable can mean 'no internet'
                 // or some other position related issues on api call failure (excluding timeout)
                 message: 'position unavailable',
             });
         })
         .finally(() => {
-            // clear any leftover timeouts
+            // Clear any leftover timeouts
             if (timeoutID) {
                 clearTimeout(timeoutID);
             }

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -18,7 +18,11 @@ const requestConfig: FetchConfigWithOptions = {
     method: 'POST',
 };
 
-const getCurrentPosition: GetCurrentPosition = (success, error, options) => {
+const getCurrentPosition: GetCurrentPosition = (
+    success,
+    error,
+    options, // we will ignore options.maximumAge and options.enableHighAccuracy since cant pass it to geolocate api directly
+) => {
     // emulate the timeout param with an abort signal
     if (options?.timeout) {
         const abortController = new AbortController();
@@ -43,7 +47,7 @@ const getCurrentPosition: GetCurrentPosition = (success, error, options) => {
                     heading: null,
                     speed: null,
                 },
-                timestamp: Date.now(), // the api call doesn't return timestamp directly, so we return ourselves
+                timestamp: Date.now(), // the api call doesn't return timestamp directly, so we emulate ourselves
             };
 
             success(transformedResponse);

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -6,14 +6,26 @@ type GoogleAPIsGeoLocateResponse = {
         lng: number;
     };
     accuracy: number;
-}
+};
+
+type FetchConfigWithOptions = {
+    method: string;
+    signal?: AbortSignal;
+};
 
 const BASE_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
-const requestConfig = {
+const requestConfig: FetchConfigWithOptions = {
     method: 'POST',
 };
 
-const getCurrentPosition: GetCurrentPosition = (success, error) => {
+const getCurrentPosition: GetCurrentPosition = (success, error, options) => {
+    // emulate the timeout param with an abort signal
+    if (options?.timeout) {
+        const abortController = new AbortController();
+        setTimeout(() => abortController.abort(), options.timeout);
+        requestConfig.signal = abortController.signal;
+    }
+
     const tempAPIToken = ''; // we get this token from our backend
 
     fetch(`${BASE_URL}?key=${tempAPIToken}`, requestConfig)

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -1,0 +1,42 @@
+import {GetCurrentPosition} from './getCurrentPosition.types';
+
+type GoogleAPIsGeoLocateResponse = {
+    location: {
+        lat: number;
+        lng: number;
+    };
+    accuracy: number;
+}
+
+const BASE_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
+const requestConfig = {
+    method: 'POST',
+};
+
+const getCurrentPosition: GetCurrentPosition = (success, error) => {
+    const tempAPIToken = ''; // we get this token from our backend
+
+    fetch(`${BASE_URL}?key=${tempAPIToken}`, requestConfig)
+        .then((response) => response.json())
+        .then((response: GoogleAPIsGeoLocateResponse) => {
+            // transform response to match with the window.navigator.geolocation.getCurrentPosition response
+            const transformedResponse = {
+                coords: {
+                    latitude: response.location.lat,
+                    longitude: response.location.lng,
+                    accuracy: response.accuracy,
+                    // return null for these keys as we don't get them in response when api is directly called
+                    altitude: null,
+                    altitudeAccuracy: null,
+                    heading: null,
+                    speed: null,
+                },
+                timestamp: Date.now(), // the api call doesn't return timestamp directly, so we return ourselves
+            };
+
+            success(transformedResponse);
+        })
+        .catch(error);
+};
+
+export default getCurrentPosition;

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -35,9 +35,8 @@ const getCurrentPosition: GetCurrentPosition = (
         requestConfig.signal = abortController.signal;
     }
 
-    const tempAPIToken = ''; // we get this token from our backend
-
-    fetch(`${BASE_URL}?key=${tempAPIToken}`, requestConfig)
+    // Gets current location from google geolocation api
+    fetch(`${BASE_URL}?key=${options?.apiToken}`, requestConfig)
         .then((response) => {
             if (!response.ok) {
                 throw new Error(response.statusText);

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -8,15 +8,10 @@ type GoogleAPIsGeoLocateResponse = {
     accuracy: number;
 };
 
-type FetchConfigWithOptions = {
-    method: string;
-    signal?: AbortSignal;
-};
-
 const BASE_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
 
 // Api request config
-const requestConfig: FetchConfigWithOptions = {
+const requestConfig: RequestInit = {
     method: 'POST',
 };
 

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -73,7 +73,7 @@ const getCurrentPosition: GetCurrentPosition = (
             };
 
             // return timeout error on abort
-            if (apiError.message === 'The user aborted a request.') {
+            if (apiError instanceof Error && apiError.message === 'The user aborted a request.') {
                 error({
                     ...baseErrorObject,
                     code: GeolocationErrorCode.TIMEOUT,

--- a/src/getCurrentPosition/getCurrentPosition.desktop.tsx
+++ b/src/getCurrentPosition/getCurrentPosition.desktop.tsx
@@ -26,9 +26,10 @@ const getCurrentPosition: GetCurrentPosition = (
     options, // we will ignore options.maximumAge and options.enableHighAccuracy since cant pass it to geolocate api directly
 ) => {
     // emulate the timeout param with an abort signal
+    let timeoutID: NodeJS.Timeout;
     if (options?.timeout) {
         const abortController = new AbortController();
-        setTimeout(() => {
+        timeoutID = setTimeout(() => {
             abortController.abort();
         }, options.timeout);
         requestConfig.signal = abortController.signal;
@@ -90,6 +91,12 @@ const getCurrentPosition: GetCurrentPosition = (
                 // or some other position related issues on api call failure (excluding timeout)
                 message: 'position unavailable',
             });
+        })
+        .finally(() => {
+            // clear any leftover timeouts
+            if (timeoutID) {
+                clearTimeout(timeoutID);
+            }
         });
 };
 

--- a/src/getCurrentPosition/getCurrentPosition.types.ts
+++ b/src/getCurrentPosition/getCurrentPosition.types.ts
@@ -45,6 +45,9 @@ export type GeolocationOptions = {
 
     /** Native only */
     fastestInterval?: number;
+
+    /** Desktop only */
+    apiToken?: string;
 };
 
 export type GetCurrentPosition = (success: GeolocationSuccessCallback, error: GeolocationErrorCallback, options?: GeolocationOptions) => void;


### PR DESCRIPTION
<!-- If necessary, assign reviewers that know the area or changes well. Feel free to tag any additional reviewers you see fit. -->

### Details
<!-- Explanation of the change or anything fishy that is going on -->
The desktop app required a `GOOGLE_API_KEY` to be baked into desktop code before opening any window for the `navigator.geolocation.getCurrentPosition` call to work. This was restricting because we wouldn't be able to have much control over the API token. From discussions about different solutions in https://github.com/Expensify/App/pull/25990, we [landed](https://github.com/Expensify/App/pull/25990#issuecomment-1694785931) on using the geolocate API directly with a temporary token that would come from the API. 

This PR adds the desktop implementation for geolocation that mimic's the format of `navigator.geolocation.getCurrentPosition`

### Related Issues
<!-- Please replace GH_LINK with the link to the GitHub issue this Pull Request is related to -->
https://github.com/Expensify/App/pull/25990
https://github.com/Expensify/App/issues/22707

### Manual Tests
<!---
Most changes should have accompanying tests. Describe the tests you added or if no tests were added an explanation about why one was not needed.
--->
1. On the E/App repo, for the desktop app import the `getCurrentLocation` function. 
2. Verify that on using the function it gives correct location data (similar to what `navigator.geolocation.getCurrentPosition` would give)


### Linked PRs
<!---
Please include links to any update PRs in repos that must change their package.json version.
--->
https://github.com/Expensify/App/pull/25990
